### PR TITLE
Add new Nature Genetics paper (segmentation errors)

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -1,5 +1,16 @@
 ---
 ---
+
+@article{mitchel2026segmentation,
+  title={Impact and correction of segmentation errors in spatial transcriptomics},
+  author={Mitchel, Jonathan* and Gao, Teng* and Petukhov, Viktor and Cole, Eli and Kharchenko, Peter V.},
+  journal={Nature Genetics},
+  month={Jan},
+  year={2026},
+  doi={10.1038/s41588-025-02497-4},
+  html={https://www.nature.com/articles/s41588-025-02497-4}
+}
+
 @article{gao2018optimization,
   title={Optimization of gelatin--alginate composite bioink printability using rheological parameters: a systematic approach},
   author={Gao, Teng and Gillispie, Gregory J and Copus, Joshua S and Pr, Anil Kumar and Seol, Young-Joon and Atala, Anthony and Yoo, James J and Lee, Sang Jin},

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -3,11 +3,12 @@ layout: page
 permalink: /publications/
 title: Publications
 description: Peer-reviewed publications and invited commentaries
-years: [2025, 2024,2023,2022,2021,2020,2018,2017]
+years: [2026, 2025, 2024,2023,2022,2021,2020,2018,2017]
 nav: true
 nav_order: 1
 ---
 <!-- _pages/publications.md -->
+<p><small>* indicates co-first authors.</small></p>
 <div class="publications">
 
 {%- for y in page.years %}


### PR DESCRIPTION
Adds the new Nature Genetics paper to _bibliography/papers.bib with co-first author stars for Jonathan Mitchel* and Teng Gao*. Also updates publications page to include 2026 and adds a small footnote explaining the star.