### PR TITLE
Fix co-first stars placement + underline

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -3,7 +3,7 @@
 
 @article{mitchel2026segmentation,
   title={Impact and correction of segmentation errors in spatial transcriptomics},
-  author={Mitchel, Jonathan* and Gao, Teng* and Petukhov, Viktor and Cole, Eli and Kharchenko, Peter V.},
+  author={Mitchel*, Jonathan and Gao*, Teng and Petukhov, Viktor and Cole, Eli and Kharchenko, Peter V.},
   journal={Nature Genetics},
   month={Jan},
   year={2026},

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -41,15 +41,16 @@
           {%- for author in entry.author_array limit: author_array_limit -%}
             {%- assign author_is_self = false -%}
             {%- assign author_last_name = author.last | remove: "¶" | remove: "&" | remove: "*" | remove: "†" | remove: "^" -%}
+            {%- assign author_first_name_clean = author.first | remove: "¶" | remove: "&" | remove: "*" | remove: "†" | remove: "^" -%}
             {%- if site.scholar.last_name contains author_last_name -%}
-              {%- if site.scholar.first_name contains author.first -%}
+              {%- if site.scholar.first_name contains author_first_name_clean -%}
                 {%- assign author_is_self = true -%}
               {%- endif -%}
             {%- endif -%}
             {%- assign coauthor_url = nil -%}
             {%- if site.data.coauthors[author_last_name] -%}
               {%- for coauthor in site.data.coauthors[author_last_name] -%}
-                {%- if coauthor.firstname contains author.first -%}
+                {%- if coauthor.firstname contains author_first_name_clean -%}
                   {%- assign coauthor_url = coauthor.url -%}
                   {%- break -%}
                 {%- endif -%}


### PR DESCRIPTION
Fixes star placement (after last name) and makes self-author highlighting robust by stripping markers from first names during matching.