### PR TITLE
Publications: star means equal contribution

### DIFF
--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -8,7 +8,7 @@ nav: true
 nav_order: 1
 ---
 <!-- _pages/publications.md -->
-<p><small>* indicates co-first authors.</small></p>
+<p><small>* indicates equal contribution.</small></p>
 <div class="publications">
 
 {%- for y in page.years %}


### PR DESCRIPTION
Updates the publications page footnote to say '*' indicates equal contribution (instead of co-first).