### PR TITLE
Bolton 2020: mark equal contribution

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -39,7 +39,7 @@
 
 @article{bolton2020cancer,
   title={Cancer therapy shapes the fitness landscape of clonal hematopoiesis},
-  author={Bolton, Kelly L and Ptashkin, Ryan N and Gao, Teng and Braunstein, Lior and Devlin, Sean M and Kelly, Daniel and Patel, Minal and Berthon, Antonin and Syed, Aijazuddin and Yabe, Mariko and others},
+  author={Bolton, Kelly L and Ptashkin*, Ryan N and Gao*, Teng and Braunstein, Lior and Devlin, Sean M and Kelly, Daniel and Patel, Minal and Berthon, Antonin and Syed, Aijazuddin and Yabe, Mariko and others},
   journal={Nature genetics},
   volume={52},
   number={11},


### PR DESCRIPTION
Marks Ptashkin* and Gao* on the Bolton 2020 Nature Genetics paper to indicate equal contribution.