### PR TITLE
Add missing journal articles to publications

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -132,3 +132,42 @@
   publisher={Nature Publishing Group},
   html={https://www.nature.com/articles/s41588-025-02250-x}
 }
+
+@article{li2025numbatmultiome,
+  title={Numbat-multiome: inferring copy number variations by combining RNA and chromatin accessibility information from single-cell data},
+  author={Li, Ruitong and Alberge, Jean-Baptiste and Keshavarzian, Tina and Tsuji, Junko and Gustafsson, Johan and Rahmat, Mahshid and Lightbody, Elizabeth D and Deng, Stephanie L and Riviero, Santiago and Miller, Mendy and Naz Cemre Kalayci, F and Wiestner, Adrian and Sun, Clare and Lupien, Mathieu and Ghobrial, Irene and Parry, Erin and Gao, Teng and Getz, Gad},
+  journal={Briefings in Bioinformatics},
+  volume={26},
+  number={5},
+  pages={bbaf516},
+  month={Aug},
+  year={2025},
+  doi={10.1093/bib/bbaf516},
+  html={https://doi.org/10.1093/bib/bbaf516}
+}
+
+@article{zhang2025scistree2,
+  title={ScisTree2 enables large-scale inference of cell lineage trees and genotype calling using efficient local search},
+  author={Zhang, Haotian and Zhang, Yiming and Gao, Teng and Wu, Yufeng},
+  journal={Genome Research},
+  volume={35},
+  number={12},
+  pages={2781-2791},
+  month={Sep},
+  year={2025},
+  doi={10.1101/gr.280542.125},
+  html={https://doi.org/10.1101/gr.280542.125}
+}
+
+@article{olsen2024neuroblastoma,
+  title={Joint single-cell genetic and transcriptomic analysis reveal pre-malignant SCP-like subclones in human neuroblastoma},
+  author={Olsen, Thale K. and Otte, Jörg and Mei, Shenglin and Embaie, Bethel Tesfai and Kameneva, Polina and Cheng, Huaitao and Gao, Teng and Zachariadis, Vasilios and Tsea, Ioanna and Björklund, Åsa and Kryukov, Emil and Hou, Ziyi and Johansson, Anna and Sundström, Erik and Martinsson, Tommy and Fransson, Susanne and Stenman, Jakob and Fard, Shahrzad Shirazi and Johnsen, John Inge and Kogner, Per and Adameyko, Igor and Enge, Martin and Kharchenko, Peter V. and Baryawno, Ninib},
+  journal={Molecular Cancer},
+  volume={23},
+  number={1},
+  pages={180},
+  month={Aug},
+  year={2024},
+  doi={10.1186/s12943-024-02091-y},
+  html={https://doi.org/10.1186/s12943-024-02091-y}
+}


### PR DESCRIPTION
Adds 3 ORCID-listed journal articles (Molecular Cancer 2024; Briefings in Bioinformatics 2025; Genome Research 2025) to _bibliography/papers.bib so they appear on /publications/.